### PR TITLE
Fixes brew warnings

### DIFF
--- a/.github/scripts/generate-formula.sh
+++ b/.github/scripts/generate-formula.sh
@@ -23,8 +23,7 @@ class ${FORMULA_CLASSNAME} < Formula
 
   bottle do
     root_url \"https://github.com/dapr/homebrew-tap/releases/download/v${DAPR_CLI_VERSION}\"
-    cellar :any_skip_relocation
-    sha256 ${DAPR_CLI_BOTTLE_OS_VERSION}: \"${DAPR_CLI_BOTTLE_SHASUM}\"
+    sha256 cellar :any_skip_relocation, ${DAPR_CLI_BOTTLE_OS_VERSION}: \"${DAPR_CLI_BOTTLE_SHASUM}\"
   end
 
   def install

--- a/dapr-cli.rb
+++ b/dapr-cli.rb
@@ -14,8 +14,7 @@ class DaprCli < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.2.0"
-    cellar :any_skip_relocation
-    sha256 catalina: "e59f32f0b96a6fbd8890082195aa85913efc190e4077705d0c04f876ab617dcc"
+    sha256 cellar :any_skip_relocation, catalina: "e59f32f0b96a6fbd8890082195aa85913efc190e4077705d0c04f876ab617dcc"
   end
 
   def install

--- a/dapr-cli@1.0.0-rc.2.rb
+++ b/dapr-cli@1.0.0-rc.2.rb
@@ -14,8 +14,7 @@ class DaprCliAT100Rc2 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.0.0-rc.2"
-    cellar :any_skip_relocation
-    sha256 catalina: "7112c0cc55c0d99724fe062148b1869223c61fdee5f140441cd7312f2c0f5520"
+    sha256 cellar :any_skip_relocation, catalina: "7112c0cc55c0d99724fe062148b1869223c61fdee5f140441cd7312f2c0f5520"
   end
 
   def install

--- a/dapr-cli@1.0.0-rc.3.rb
+++ b/dapr-cli@1.0.0-rc.3.rb
@@ -14,8 +14,7 @@ class DaprCliAT100Rc3 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.0.0-rc.3"
-    cellar :any_skip_relocation
-    sha256 catalina: "3b89a889490f984ecc8922135d025691a98956bb741910921f65a7f28c3411bd"
+    sha256 cellar :any_skip_relocation, catalina: "3b89a889490f984ecc8922135d025691a98956bb741910921f65a7f28c3411bd"
   end
 
   def install

--- a/dapr-cli@1.0.0-rc.4.rb
+++ b/dapr-cli@1.0.0-rc.4.rb
@@ -14,8 +14,7 @@ class DaprCliAT100Rc4 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.0.0-rc.4"
-    cellar :any_skip_relocation
-    sha256 catalina: "4921aa243825fed40ac38c260aa3ecb7c499d96c74c5288b676002398d16dbd2"
+    sha256 cellar :any_skip_relocation, catalina: "4921aa243825fed40ac38c260aa3ecb7c499d96c74c5288b676002398d16dbd2"
   end
 
   def install

--- a/dapr-cli@1.0.0-rc.5.rb
+++ b/dapr-cli@1.0.0-rc.5.rb
@@ -14,8 +14,7 @@ class DaprCliAT100Rc5 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.0.0-rc.5"
-    cellar :any_skip_relocation
-    sha256 catalina:"8d7b70d4335ed6718ec6156219f7fba1e366a6abc99ecf62860b9e5a37c60a03"
+    sha256 cellar :any_skip_relocation, catalina:"8d7b70d4335ed6718ec6156219f7fba1e366a6abc99ecf62860b9e5a37c60a03"
   end
 
   def install

--- a/dapr-cli@1.0.0-rc.6.rb
+++ b/dapr-cli@1.0.0-rc.6.rb
@@ -14,8 +14,7 @@ class DaprCliAT100Rc6 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.0.0-rc.6"
-    cellar :any_skip_relocation
-    sha256 catalina: "31e2c91b132fb132518504ddaa097d3fcc47e319abc2642d66e3144f121563bc"
+    sha256 cellar :any_skip_relocation, catalina: "31e2c91b132fb132518504ddaa097d3fcc47e319abc2642d66e3144f121563bc"
   end
 
   def install

--- a/dapr-cli@1.0.0-rc.7.rb
+++ b/dapr-cli@1.0.0-rc.7.rb
@@ -14,8 +14,7 @@ class DaprCliAT100Rc7 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.0.0-rc.7"
-    cellar :any_skip_relocation
-    sha256 catalina: "6479bd3f3fa69f03a7dbf1817ba9b559dd1e15d0d509f3c20536fc0d80ce2ede"
+    sha256 cellar :any_skip_relocation, catalina: "6479bd3f3fa69f03a7dbf1817ba9b559dd1e15d0d509f3c20536fc0d80ce2ede"
   end
 
   def install

--- a/dapr-cli@1.1.0-rc.1.rb
+++ b/dapr-cli@1.1.0-rc.1.rb
@@ -14,8 +14,7 @@ class DaprCliAT110Rc1 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.1.0-rc.1"
-    cellar :any_skip_relocation
-    sha256 catalina: "f82db5d04edc9a61a2d10d82fdbc8b5231bb36441c4661469b062f4d9fd47403"
+    sha256 cellar :any_skip_relocation, catalina: "f82db5d04edc9a61a2d10d82fdbc8b5231bb36441c4661469b062f4d9fd47403"
   end
 
   def install

--- a/dapr-cli@1.2.0-rc.1.rb
+++ b/dapr-cli@1.2.0-rc.1.rb
@@ -14,8 +14,7 @@ class DaprCliAT120Rc1 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.2.0-rc.1"
-    cellar :any_skip_relocation
-    sha256 "82729d8236ead555862e2934fdc995c62a2187cdd72133969221c2e6183c509b" => :catalina
+    sha256 cellar :any_skip_relocation, catalina: "82729d8236ead555862e2934fdc995c62a2187cdd72133969221c2e6183c509b"
   end
 
   def install

--- a/dapr-cli@1.2.0-rc.2.rb
+++ b/dapr-cli@1.2.0-rc.2.rb
@@ -14,8 +14,7 @@ class DaprCliAT120Rc2 < Formula
 
   bottle do
     root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.2.0-rc.2"
-    cellar :any_skip_relocation
-    sha256 catalina: "308a5159037153f52c9d96773da00411456d2d94554e3a123f68c3ba4e1406d2"
+    sha256 cellar :any_skip_relocation, catalina: "308a5159037153f52c9d96773da00411456d2d94554e3a123f68c3ba4e1406d2"
   end
 
   def install


### PR DESCRIPTION
As mentioned in #19, `cellar` is also moved in the single line configuration for homebrew