### PR TITLE
Fix build to use make - required for 1.4.x

### DIFF
--- a/.github/scripts/generate-formula.sh
+++ b/.github/scripts/generate-formula.sh
@@ -20,6 +20,7 @@ class ${FORMULA_CLASSNAME} < Formula
   sha256 \"${DAPR_CLI_SRC_SHASUM}\"
 
   depends_on \"go\" => :build
+  depends_on \"make\" => :build
 
   bottle do
     root_url \"https://github.com/dapr/homebrew-tap/releases/download/v${DAPR_CLI_VERSION}\"
@@ -27,8 +28,8 @@ class ${FORMULA_CLASSNAME} < Formula
   end
 
   def install
-    system \"go\", \"build\", \"-ldflags\", \"-X main.version=#{version} -X main.apiVersion=1.0\", \"-o\", \"./cli\"
-    bin.install \"cli\" => \"dapr\"
+    system \"make\", \"REL_VERSION=#{version}\"
+    bin.install \"dist/darwin_amd64/release/dapr\" => \"dapr\"
   end
 
   test do

--- a/.github/scripts/generate-temp-formula.sh
+++ b/.github/scripts/generate-temp-formula.sh
@@ -20,10 +20,11 @@ class ${FORMULA_CLASSNAME} < Formula
   sha256 \"${DAPR_CLI_SRC_SHASUM}\"
 
   depends_on \"go\" => :build
+  depends_on \"make\" => :build
 
   def install
-    system \"go\", \"build\", \"-ldflags\", \"-X main.version=#{version} -X main.apiVersion=1.0\", \"-o\", \"./cli\"
-    bin.install \"cli\" => \"dapr\"
+    system \"make\", \"REL_VERSION=#{version}\"
+    bin.install \"dist/darwin_amd64/release/dapr\" => \"dapr\"
   end
 
   test do

--- a/dapr-cli@1.4.0-rc.1.rb
+++ b/dapr-cli@1.4.0-rc.1.rb
@@ -11,15 +11,11 @@ class DaprCliAT140Rc1 < Formula
   sha256 "7107c40a236b061637c342f10e5b92a0c33dc88c2ac320343de34b04139acb82"
 
   depends_on "go" => :build
-
-  bottle do
-    root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.4.0-rc.1"
-    sha256 cellar: :any_skip_relocation, catalina: "3b06e38e51ab53396763eb31d1886c73b3125e2b554e4af5a9f55522ffad15eb"
-  end
+  depends_on "make" => :build
 
   def install
-    system "go", "build", "-ldflags", "-X main.version=#{version} -X main.apiVersion=1.0", "-o", "./cli"
-    bin.install "cli" => "dapr"
+    system "make", "REL_VERSION=#{version}"
+    bin.install "dist/darwin_amd64/release/dapr" => "dapr"
   end
 
   test do

--- a/dapr-cli@1.4.0-rc.2.rb
+++ b/dapr-cli@1.4.0-rc.2.rb
@@ -11,15 +11,11 @@ class DaprCliAT140Rc2 < Formula
   sha256 "0d876a70de55032895aff4caa9fb2b00e26dae119c6c4c79ebff7d5352081198"
 
   depends_on "go" => :build
-
-  bottle do
-    root_url "https://github.com/dapr/homebrew-tap/releases/download/v1.4.0-rc.2"
-    sha256 cellar: :any_skip_relocation, catalina: "1fc503d813a3ede5d3f5586f267cd284ba4061a535fd917ec77cc675f076cd86"
-  end
+  depends_on "make" => :build
 
   def install
-    system "go", "build", "-ldflags", "-X main.version=#{version} -X main.apiVersion=1.0", "-o", "./cli"
-    bin.install "cli" => "dapr"
+    system "make", "REL_VERSION=#{version}"
+    bin.install "dist/darwin_amd64/release/dapr" => "dapr"
   end
 
   test do


### PR DESCRIPTION
CGO_ENABLED=0 is required now in 1.4, so the binaries fails to run. Now, it will use the official make target instead of keeping another build command here.